### PR TITLE
Update SlackBot test so it runs out of the box

### DIFF
--- a/tests/jt2k/Jarvis/Main/SlackBotTest.php
+++ b/tests/jt2k/Jarvis/Main/SlackBotTest.php
@@ -7,6 +7,7 @@ class SlackBotTest extends PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
+        $GLOBALS['jarvis_config']['slackbot_token'] = 'FOOBAR123';
         $this->bot = new SlackBot($GLOBALS['jarvis_config']);
     }
 
@@ -28,5 +29,14 @@ class SlackBotTest extends PHPUnit_Framework_TestCase
         $this->assertContains('Bot type: SlackBot', $response);
         $this->assertRegExp('/PID: \d+/', $response);
         $this->assertRegExp('/Memory usage: \d/', $response);
+    }
+
+    public function testMissingConfiguration()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('slackbot_token must be configured');
+
+        $this->bot = new SlackBot([]);
+        $this->respond('status');
     }
 }


### PR DESCRIPTION
This allows the repository to be tested without a `config.php` file.

- Still tests that the adapter was set up properlty
- Adds test case for missing configuration