### PR TITLE
Add typical properties to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,8 @@
 {
+    "name": "jt2k/jarvis",
+    "license": "MIT",
+    "type": "project",
+    "description": "Jarvis is a multi-modal chat bot written in PHP",
     "require": {
         "swiftmailer/swiftmailer": "@stable",
         "simplepie/simplepie": "1.3.*",


### PR DESCRIPTION
I was playing around with trying to include this repo as a `require-dev`, but Composer was generating errors like:

>Skipped branch master, Undefined index: name

This PR adds the `name` and a few typical properties to composer.json.

⚠️ **WARNING:** I defined license as MIT, which may or may not be what you want.